### PR TITLE
fix: correct response time calculation for P4 in Round Robin example

### DIFF
--- a/s4_operating_system/Unit 2/03.CPU_Scheduling.md
+++ b/s4_operating_system/Unit 2/03.CPU_Scheduling.md
@@ -229,7 +229,7 @@ To compare scheduling algorithms, we use these metrics:
 | P1 | 0 | 5 | 12 | 12 | 7 | 0 |
 | P2 | 1 | 4 | 11 | 10 | 6 | 1 |
 | P3 | 2 | 2 | 6 | 4 | 2 | 2 |
-| P4 | 4 | 1 | 9 | 5 | 4 | 5 |
+| P4 | 4 | 1 | 9 | 5 | 4 | 4 |
 
 **Ready Queue Progression**:
 `P1 -> P2 -> P3 -> P1 -> P4 -> P2 -> P1`


### PR DESCRIPTION
## Summary
Corrected the Response Time (RT) calculation for process P4 in the Round Robin scheduling example.

## Changes Made
- Updated RT of P4 from `5` to `4`
- Verified Response Time formula:
  
  RT = First CPU Allocation Time - Arrival Time

## Correct Calculation
For P4:
- Arrival Time = 4
- First CPU Allocation = 8

Therefore:
RT = 8 - 4 = 4

## Impact
This fixes the inconsistency in the scheduling metrics table and aligns the example with standard Round Robin scheduling calculations.